### PR TITLE
Fixed Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN pip3 install --no-cache-dir \
 COPY setup.py /app/
 COPY main.py /app/
 COPY utils/ /app/utils/
+COPY model_data /app/model_data
+
 
 # Run the setup script to download the ONNX model
 RUN python3 setup.py


### PR DESCRIPTION
Currently, the Dockerfile does not account for the critical model_data directory, which contains the YOLOv4 model files essential for the project's operation.

As a solution, I suggest adding the following line to the Dockerfile:

```terminal
COPY model_data /app/model_data
```